### PR TITLE
Add support for Windows

### DIFF
--- a/scripts/average_time.py
+++ b/scripts/average_time.py
@@ -1,31 +1,31 @@
 import search_compiler as sc
 from search_compiler import unitaries, advanced_unitaries
 import time
-project = sc.Project("benchmarks")
-project.add_compilation("qft2", unitaries.qft(4))
-project.add_compilation("qft3", unitaries.qft(8))
-project.add_compilation("fredkin", unitaries.fredkin)
-project.add_compilation("toffoli", unitaries.toffoli)
-project.add_compilation("peres", unitaries.peres)
-project.add_compilation("or", unitaries.logical_or)
+if __name__ == '__main__':
+    project = sc.Project("benchmarks")
+    project.add_compilation("qft2", unitaries.qft(4))
+    project.add_compilation("qft3", unitaries.qft(8))
+    project.add_compilation("fredkin", unitaries.fredkin)
+    project.add_compilation("toffoli", unitaries.toffoli)
+    project.add_compilation("peres", unitaries.peres)
+    project.add_compilation("or", unitaries.logical_or)
 
-project.add_compilation("miro", advanced_unitaries.mirogate)
-project.add_compilation("hhl", advanced_unitaries.HHL)
+    project.add_compilation("miro", advanced_unitaries.mirogate)
+    project.add_compilation("hhl", advanced_unitaries.HHL)
 
+    # run the benchmarks script with default settings 10x and average the timing results
+    # reported times are between 0.1s and 5s on my 2018 Macbook Pro
 
-# run the benchmarks script with default settings 10x and average the timing results
-# reported times are between 0.1s and 5s on my 2018 Macbook Pro
-
-times = {}
-for compilation in project.compilations:
-    times[compilation] = 0
-
-for _ in range(10):
-    project.reset()
-    project.run()
+    times = {}
     for compilation in project.compilations:
-        times[compilation] += project.get_time(compilation)
+        times[compilation] = 0
 
-for compilation in project.compilations:
-    print(f'Compilation {compilation} took {times[compilation]/10}s on average.')
+    for _ in range(10):
+        project.reset()
+        project.run()
+        for compilation in project.compilations:
+            times[compilation] += project.get_time(compilation)
+
+    for compilation in project.compilations:
+        print(f'Compilation {compilation} took {times[compilation]/10}s on average.')
 

--- a/scripts/benchmarks.py
+++ b/scripts/benchmarks.py
@@ -2,40 +2,42 @@ import search_compiler as sc
 from search_compiler import unitaries, advanced_unitaries
 import time
 
-# create the project
-project = sc.Project("benchmarks")
+if __name__ == '__main__':
+    # create the project
+    project = sc.Project("benchmarks")
 
-# add a unitaries to compile
-project.add_compilation("qft2", unitaries.qft(4))
-project.add_compilation("qft3", unitaries.qft(8))
-project.add_compilation("fredkin", unitaries.fredkin)
-project.add_compilation("toffoli", unitaries.toffoli)
-project.add_compilation("peres", unitaries.peres)
-project.add_compilation("or", unitaries.logical_or)
+    # add a unitaries to compile
+    project.add_compilation("qft2", unitaries.qft(4))
+    project.add_compilation("qft3", unitaries.qft(8))
+    project.add_compilation("fredkin", unitaries.fredkin)
+    project.add_compilation("toffoli", unitaries.toffoli)
+    project.add_compilation("peres", unitaries.peres)
+    project.add_compilation("or", unitaries.logical_or)
 
-project.add_compilation("miro", advanced_unitaries.mirogate)
-project.add_compilation("hhl", advanced_unitaries.HHL)
+    project.add_compilation("miro", advanced_unitaries.mirogate)
+    project.add_compilation("hhl", advanced_unitaries.HHL)
 
-# 4 qubit benchmarks (WARNING: These may take days to run.)
-#project.add_compilation("qft4", unitaries.qft(16))
-#project.add_compilation("full adder", unitaries.full_adder)
-#project.add_compilation("ethylene", advanced_unitaries.ethylene)
-
-
-# compiler configuration example
-#project["gateset"] = sc.gatesets.QubitCNOTRing() # use this to synthesize for the ring topology instead of the default line topology
-#project["solver"]  = sc.solver.BFGS_Jac_SolverNative() # use this to force the compiler to use the Rust version of the BFGS solver instead of using the default setting
-#project["verbosity"] = 2 # use this to have more information reported to stdout and the log files, or set it to 0 to disable logging altogether
-
-# once everything is set up, let the project run!
-project.run()
+    # 4 qubit benchmarks (WARNING: These may take days to run.)
+    #project.add_compilation("qft4", unitaries.qft(16))
+    #project.add_compilation("full adder", unitaries.full_adder)
+    #project.add_compilation("ethylene", advanced_unitaries.ethylene)
 
 
-# once its done you can use the following functions to get output
-# compilation_names = project.compilations # returns a list of the names that were specified when adding unitaries
-# circuit, vector = project.get_result(compilation_names[0]) # get a circuit/vector combination, which is the search_compiler format for describing finished circuits
-# project.assemble(compilation_names[0], write_location="my_circuit.qasm") # export the circuit as openqasm
-# project.assemble(compilation_names[0], language=assembly.ASSEMBLY_QISKIT, write_location="my_circuit.py") # export the circuit as a qiskit script
+    # compiler configuration example
+    #project["gateset"] = sc.gatesets.QubitCNOTRing() # use this to synthesize for the ring topology instead of the default line topology
+    #project["solver"]  = sc.solver.BFGS_Jac_SolverNative() # use this to force the compiler to use the Rust version of the BFGS solver instead of using the default setting
+    #project["verbosity"] = 2 # use this to have more information reported to stdout and the log files, or set it to 0 to disable logging altogether
 
-# Read the wiki for more information and more features: https://github.com/WolfLink/search_compiler/wiki
+    # once everything is set up, let the project run!
+
+    project.run()
+
+
+    # once its done you can use the following functions to get output
+    # compilation_names = project.compilations # returns a list of the names that were specified when adding unitaries
+    # circuit, vector = project.get_result(compilation_names[0]) # get a circuit/vector combination, which is the search_compiler format for describing finished circuits
+    # project.assemble(compilation_names[0], write_location="my_circuit.qasm") # export the circuit as openqasm
+    # project.assemble(compilation_names[0], language=assembly.ASSEMBLY_QISKIT, write_location="my_circuit.py") # export the circuit as a qiskit script
+
+    # Read the wiki for more information and more features: https://github.com/WolfLink/search_compiler/wiki
 

--- a/search_compiler/project.py
+++ b/search_compiler/project.py
@@ -6,6 +6,7 @@ from enum import Enum
 import os
 import shutil
 import pickle
+from multiprocessing import freeze_support
 from .compiler import SearchCompiler
 from . import solver as scsolver
 from . import logging, checkpoint, utils, gatesets, heuristics, assembler
@@ -130,6 +131,7 @@ class Project:
         self._save()
 
     def run(self, target=None):
+        freeze_support()
         self.logger.logprint("Started running project {}".format(self.name))
         threshold = self._config("threshold", 1e-10)
         gateset = self._config("gateset", gatesets.QubitCNOTLinear())


### PR DESCRIPTION
This is mostly putting stuff in a `if __name__ == '__main__` guard so that when Python spawns new instances it doesn't duplicate everything.

Also added a call to `freeze_support()` which is a no-op on all platforms but Windows, and silences an annoying warning if it isn't there.